### PR TITLE
Feat/column detail 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,10 @@ function App() {
             --color-gray: #aaa;
             --color-black: #2c2c2c;
           }
+          p,
+          li {
+            line-height: 120%;
+          }
         `}
       />
       <RouterProvider router={router} />

--- a/src/pages/ColumnDetail/Content.tsx
+++ b/src/pages/ColumnDetail/Content.tsx
@@ -1,0 +1,122 @@
+import styled from '@emotion/styled';
+import type { Content } from './type';
+import { useRef } from 'react';
+import { keyframes } from '@emotion/react';
+
+export default function Content({ content }: { content: Content[] }) {
+  const refs = useRef<{ [key: string]: HTMLElement | null }>({});
+
+  const scrollToElement = (index: number) => {
+    if (!refs.current[index]) return;
+
+    refs.current[index].scrollIntoView({ behavior: 'smooth' });
+    refs.current[index].classList.add('highlight');
+
+    refs.current[index].addEventListener(
+      'animationend',
+      () => {
+        refs.current[index]!.classList.remove('highlight');
+      },
+      { once: true },
+    );
+  };
+
+  return (
+    <>
+      <Index>
+        {content.map((item, index) => {
+          switch (item.tag) {
+            case 'h2':
+              return (
+                <li key={index} onClick={() => scrollToElement(index)}>
+                  {item.content}
+                </li>
+              );
+            case 'h3':
+              return (
+                <li key={index} onClick={() => scrollToElement(index)}>
+                  &nbsp;&nbsp;{item.content}
+                </li>
+              );
+          }
+        })}
+      </Index>
+      <ContentContainer>
+        {content.map((item, index) => {
+          switch (item.tag) {
+            case 'h2':
+              return (
+                <H2 key={index} ref={(el) => (refs.current[index] = el)}>
+                  {item.content}
+                </H2>
+              );
+            case 'h3':
+              return (
+                <H3 key={index} ref={(el) => (refs.current[index] = el)}>
+                  {item.content}
+                </H3>
+              );
+            case 'p':
+              return <P key={index}>{item.content}</P>;
+            case 'img':
+              return <Img key={index} src={item.content} alt="컬럼의 설명을 돕는 이미지" />;
+          }
+        })}
+      </ContentContainer>
+    </>
+  );
+}
+
+const Index = styled.ul`
+  position: fixed;
+  top: 200px;
+  right: 0;
+  width: calc((100vw - 700px) / 2 - 20px);
+  color: var(--color-gray);
+  font-size: 12px;
+  cursor: pointer;
+  li:hover {
+    text-decoration: underline;
+  }
+`;
+const ContentContainer = styled.div`
+  width: 700px;
+  margin: 0 auto;
+`;
+
+const highlight = keyframes`
+  0% {
+    background-color: #fff;
+  }
+  50% {
+    background-color: var(--color-main);
+  }
+  100% {
+    background-color: #fff;
+  }
+`;
+const H2 = styled.h2`
+  font-size: 20px;
+  font-weight: bold;
+  margin-top: 20px;
+  &.highlight {
+    animation: ${highlight} 1s ease-out;
+  }
+`;
+const H3 = styled.h3`
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: 15px;
+  &.highlight {
+    animation: ${highlight} 1s ease-out;
+  }
+`;
+const P = styled.p`
+  margin-top: 10px;
+`;
+const Img = styled.img`
+  width: 500px;
+  margin: 20px 100px;
+  border-radius: 10px;
+  margin-top: 10px;
+`;

--- a/src/pages/ColumnDetail/Header.tsx
+++ b/src/pages/ColumnDetail/Header.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+type Props = {
+  title: string;
+  imgurl: string;
+  createdAt: string;
+  auth: string;
+  keyword: string[];
+};
+export default function Header({ title, imgurl, createdAt, auth, keyword }: Props) {
+  return (
+    <>
+      <HeaderContainer imgurl={imgurl}>
+        <Title>{title}</Title>
+        <ColumnInfo>
+          {createdAt} {auth}
+        </ColumnInfo>
+      </HeaderContainer>
+      <Keywords>
+        {keyword.map((i) => (
+          <Keyword key={i}>{i}</Keyword>
+        ))}
+      </Keywords>
+    </>
+  );
+}
+
+const HeaderContainer = styled.div<{ imgurl: string }>`
+  text-align: center;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${(props) => props.imgurl});
+  padding: 26px 100px 10px;
+`;
+const Keywords = styled.div`
+  display: flex;
+  justify-content: center;
+  border-bottom: 1px solid var(--color-gray);
+  margin: 0 100px;
+`;
+const Keyword = styled.div`
+  display: inline-block;
+  font-size: 14px;
+  border: 1px solid var(--color-gray);
+  border-radius: 10px;
+  padding: 6px;
+  margin: 6px 3px;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: bold;
+  color: #fff;
+`;
+const ColumnInfo = styled.div`
+  font-size: 16px;
+  color: #fff;
+  width: 100%;
+  text-align: right;
+`;

--- a/src/pages/ColumnDetail/index.tsx
+++ b/src/pages/ColumnDetail/index.tsx
@@ -1,3 +1,37 @@
+import Header from './Header';
+
+const data = {
+  id: '1',
+  title: '칼럼의 제목이 여기에 들어갑니다',
+  imgurl: 'https://cdn.imweb.me/upload/S2017101359e025984d346/ad539f598e444.jpg',
+  createdAt: '2020-01-01',
+  auth: '작성자',
+  keyword: ['키워드1', '키워드2', '키워드3'],
+  content: [
+    {
+      tag: 'h2',
+      content: '제목입니다.',
+    },
+    {
+      tag: 'p',
+      content: '내용입니다.',
+    },
+    {
+      tag: 'img',
+      content: 'https://cdn.imweb.me/upload/S2017101359e025984d346/ad539f598e444.jpg',
+    },
+  ],
+};
 export default function ColumnDetail() {
-  return <div>ColumnDetail</div>;
+  return (
+    <>
+      <Header
+        title={data.title}
+        imgurl={data.imgurl}
+        createdAt={data.createdAt}
+        auth={data.auth}
+        keyword={data.keyword}
+      />
+    </>
+  );
 }

--- a/src/pages/ColumnDetail/index.tsx
+++ b/src/pages/ColumnDetail/index.tsx
@@ -1,6 +1,8 @@
+import Content from './Content';
 import Header from './Header';
+import type { ColumnDetail } from './type';
 
-const data = {
+const data: ColumnDetail = {
   id: '1',
   title: '칼럼의 제목이 여기에 들어갑니다',
   imgurl: 'https://cdn.imweb.me/upload/S2017101359e025984d346/ad539f598e444.jpg',
@@ -13,8 +15,17 @@ const data = {
       content: '제목입니다.',
     },
     {
+      tag: 'h3',
+      content: '제목입니다.',
+    },
+    {
       tag: 'p',
-      content: '내용입니다.',
+      content:
+        '내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.내용입니다.',
+    },
+    {
+      tag: 'h2',
+      content: '제목입니다.',
     },
     {
       tag: 'img',
@@ -32,6 +43,7 @@ export default function ColumnDetail() {
         auth={data.auth}
         keyword={data.keyword}
       />
+      <Content content={data.content} />
     </>
   );
 }

--- a/src/pages/ColumnDetail/type.ts
+++ b/src/pages/ColumnDetail/type.ts
@@ -1,0 +1,14 @@
+export type Content = {
+  tag: 'h2' | 'h3' | 'p' | 'img';
+  content: string;
+};
+
+export type ColumnDetail = {
+  id: string;
+  title: string;
+  imgurl: string;
+  createdAt: string;
+  auth: string;
+  keyword: string[];
+  content: Content[];
+};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a1cf390c-364b-4fcd-b655-88b0eddbdd1c)

## 구현한 기능
- 컬럼 상세 페이지 구현했습니다.

## 확인해주세요!!
- content의 각 항목은 h2, h3, p, img 총 네 종류입니다(그냥 html string으로 저장하고 넣어버리면 목차 이동 기능을 구현할 수 없어 이와같이 구현했습니다)
- 컬럼 본문 내용의 width를 700으로 고정했습니다. 제 노트북 화면이 심하게 작아서 이와 같이 설정했는데, 다른 큰 화면에서도 괜찮은지 확인이 필요합니다.